### PR TITLE
fix deprecated selectors

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-atom-text-editor, :host {
+atom-text-editor,atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -51,259 +51,259 @@ atom-text-editor, :host {
   }
 }
 
-atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region,
+atom-text-editor .search-results .syntax--marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region,
+atom-text-editor .search-results .syntax--marker.current-result .region {
   border: 1px solid @syntax-result-marker-color-selected;
 }
 
-.comment {
+.syntax--comment {
     color: @comment;
 }
 
-.keyword {
+.syntax--keyword {
     color: @keyword;
     font-weight: bold;
 
-    &.control {
+    &.syntax--control {
         color: @keyword;
     }
 
-    &.operator {
+    &.syntax--operator {
         color: @syntax-text-color;
     }
 
-    &.other.special-method {
+    &.syntax--other.syntax--special-method {
         color: @keyword;
     }
 
-    &.other.unit {
+    &.syntax--other.syntax--unit {
         color: @keyword;
     }
 }
 
-.storage {
+.syntax--storage {
     color: @type;
 }
 
-.constant {
+.syntax--constant {
     color: @const;
 
-    &.character.escape {
+    &.syntax--character.syntax--escape {
         color: @builtin;
     }
 
-    &.numeric {
+    &.syntax--numeric {
         color: @const;
     }
 
-    &.other.color {
+    &.syntax--other.syntax--color {
         color: @builtin;
     }
 
-    &.other.symbol {
+    &.syntax--other.syntax--symbol {
         color: darken(@const, 10%);
     }
 }
 
-.variable {
+.syntax--variable {
     color: @var;
 
-    &.interpolation {
+    &.syntax--interpolation {
         color: darken(@var, 10%);
     }
 
-    &.parameter.function {
+    &.syntax--parameter.syntax--function {
         color: @syntax-text-color;
     }
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
     background-color: @warning2;
     color: @syntax-background-color;
 }
 
-.string {
+.syntax--string {
     color: @string;
 
 
-    &.regexp {
+    &.syntax--regexp {
         color: @builtin;
 
-        .source.ruby.embedded {
+        .syntax--source.syntax--ruby.syntax--embedded {
             color: @string;
         }
     }
 
-    &.other.link {
+    &.syntax--other.syntax--link {
         color: @string;
     }
 }
 
-.punctuation {
-    &.definition {
-        &.comment {
+.syntax--punctuation {
+    &.syntax--definition {
+        &.syntax--comment {
             color: @comment;
         }
 
-        &.string,
-        &.variable,
-        &.parameters,
-        &.array {
+        &.syntax--string,
+        &.syntax--variable,
+        &.syntax--parameters,
+        &.syntax--array {
             color: @syntax-text-color;
         }
 
-        &.heading,
-        &.identity {
+        &.syntax--heading,
+        &.syntax--identity {
             color: @keyword;
         }
 
-        &.bold {
+        &.syntax--bold {
             color: @warning2;
             font-weight: bold;
         }
 
-        &.italic {
+        &.syntax--italic {
             color: @type;
             font-style: italic;
         }
     }
 
-    &.section.embedded {
+    &.syntax--section.syntax--embedded {
         color: darken(@string, 10%);
     }
 
 }
 
-.support {
-    &.class {
+.syntax--support {
+    &.syntax--class {
         color: @type;
     }
 
-    &.function  {
+    &.syntax--unction  {
         color: @builtin;
 
-        &.any-method {
+        &.syntax--any-method {
             color: @keyword;
         }
     }
 }
 
-.entity {
-    &.name.function {
+.syntax--entity {
+    &.syntax--name.fsyntax--unction {
         color: @func;
         font-weight: bold;
     }
 
-    &.name.type {
+    &.syntax--name.syntax--type {
         color: @type;
     }
 
-    &.other.inherited-class {
+    &.syntax--other.syntax--inherited-class {
         color: @const;
     }
-    &.name.class, &.name.type.class {
+    &.syntax--name.syntax--class, &.syntax--name.syntax--type.syntax--class {
         color: @type;
     }
 
-    &.name.section {
+    &.syntax--name.syntax--section {
         color: @keyword;
     }
 
-    &.name.tag {
+    &.syntax--name.syntax--tag {
         color: @type;
-        
+
     }
 
-    &.other.attribute-name {
+    &.syntax--other.syntax--attribute-name {
         color: @keyword;
 
-        &.id {
+        &.syntax--id {
             color: @keyword;
         }
     }
 }
 
-.meta {
-    &.class {
+.syntax--meta {
+    &.syntax--class {
         color: @type;
     }
 
-    &.link {
+    &.syntax--link {
         color: @type;
     }
 
-    &.require {
+    &.syntax--require {
         color: @keyword;
     }
 
-    &.selector {
+    &.syntax--selector {
         color: @type;
     }
 
-    &.separator {
+    &.syntax--separator {
         background-color: @bg3;
         color: @syntax-text-color;
     }
 }
 
-.none {
+.syntax--none {
     color: @syntax-text-color;
 }
 
-.markup {
-    &.bold {
+.syntax--markup {
+    &.syntax--bold {
         color: @warning2;
         font-weight: bold;
     }
 
-    &.changed {
+    &.syntax--changed {
         color: @type;
     }
 
-    &.deleted {
+    &.syntax--deleted {
         color: @string;
     }
 
-    &.italic {
+    &.syntax--italic {
         color: @type;
         font-style: italic;
     }
 
-    &.heading .punctuation.definition.heading {
+    &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
         color: @keyword;
     }
 
-    &.inserted {
+    &.syntax--inserted {
         color: @const;
     }
 
-    &.list {
+    &.syntax--list {
         color: @string;
     }
 
-    &.quote {
+    &.syntax--quote {
         color: @warning;
     }
 
-    &.raw.inline {
+    &.syntax--raw.syntax--inline {
         color: @const;
     }
 }
 
-.source.gfm .markup {
+.syntax--source.syntax--gfm .syntax--markup {
     -webkit-font-smoothing: auto;
-    &.heading {
+    &.syntax--heading {
         color: @const;
     }
 }
 
 atom-text-editor[mini] .scroll-view,
-:host([mini]) .scroll-view {
+atom-text-editor .scroll-view {
     padding-left: 1px;
 }


### PR DESCRIPTION
Fixes the deprecated warnings below:

"Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. "

Signed-off-by: Derek Smart <derek@grindaga.com>